### PR TITLE
Switch to embedded-hal 0.2 by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,12 @@ description = "HAL for the Bouffalo Lab BL702 microcontroller family"
 
 [dependencies]
 bl702-pac = "0.0.2"
-embedded-hal = "=1.0.0-alpha.5"
 embedded-time = "0.12.0"
 riscv = "0.8.0"
 nb = "1.0"
 paste = "1.0"
-
-[dependencies.embedded-hal-zero]
-version = "0.2.7"
-package = "embedded-hal"
-features = ["unproven"]
+embedded-hal = { version="0.2.7", features = ["unproven"] }
+embedded-hal-alpha = { version="=1.0.0-alpha.5", package = "embedded-hal" }
 
 [dev-dependencies]
 riscv-rt = "0.9.0"

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use bl702_hal as hal;
-use embedded_hal::digital::blocking::OutputPin;
+use embedded_hal_alpha::digital::blocking::OutputPin;
 use hal::{
     clock::{board_clock_init, system_init, ClockConfig},
     delay::McycleDelay,
@@ -11,7 +11,7 @@ use hal::{
 };
 use panic_halt as _;
 
-use embedded_hal::delay::blocking::DelayMs;
+use embedded_hal_alpha::delay::blocking::DelayMs;
 
 #[riscv_rt::entry]
 fn main() -> ! {

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -2,15 +2,12 @@
 #![no_main]
 
 use bl702_hal::{
-    self as hal,
-    clock::{board_clock_init, system_init, ClockConfig, SysclkFreq, UART_PLL_FREQ},
-    delay::McycleDelay,
+    clock::{board_clock_init, system_init, ClockConfig},
     pac,
     prelude::*,
     uart::*,
 };
 use core::fmt::Write;
-use embedded_hal::serial::Read;
 use embedded_hal_alpha::delay::blocking::DelayMs;
 
 use embedded_hal_alpha::digital::blocking::OutputPin;
@@ -51,12 +48,10 @@ fn main() -> ! {
     let mut d = bl702_hal::delay::McycleDelay::new(bl702_hal::SYSFREQ);
 
     let hello = "hello rust!\r\n";
-    let mut i = 0;
     loop {
         d.delay_ms(100).unwrap();
-        i += 1;
         let t = serial.write_str(hello);
-        let x = match t {
+        let _ = match t {
             Ok(_) => led.set_high().unwrap(),
             Err(_) => led.set_low().unwrap(),
         };

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -10,10 +10,10 @@ use bl702_hal::{
     uart::*,
 };
 use core::fmt::Write;
-use embedded_hal::delay::blocking::DelayMs;
-use embedded_hal_zero::serial::Read;
+use embedded_hal::serial::Read;
+use embedded_hal_alpha::delay::blocking::DelayMs;
 
-use embedded_hal::digital::blocking::OutputPin;
+use embedded_hal_alpha::digital::blocking::OutputPin;
 use panic_halt as _;
 
 #[riscv_rt::entry]

--- a/examples/serial_echo.rs
+++ b/examples/serial_echo.rs
@@ -2,9 +2,7 @@
 #![no_main]
 
 use bl702_hal::{
-    self as hal,
-    clock::{board_clock_init, system_init, ClockConfig, SysclkFreq, UART_PLL_FREQ},
-    delay::McycleDelay,
+    clock::{board_clock_init, system_init, ClockConfig},
     pac,
     prelude::*,
     uart::*,
@@ -50,7 +48,8 @@ fn main() -> ! {
     loop {
         let r = serial.read();
         if let Ok(r) = r {
-            serial.write_char(r as char);
+            // ignore write errors for this example
+            let _ = serial.write_char(r as char);
         }
     }
 }

--- a/examples/serial_echo.rs
+++ b/examples/serial_echo.rs
@@ -47,9 +47,6 @@ fn main() -> ! {
         clocks,
     );
 
-    // Create a blocking delay function based on the current cpu frequency
-    let mut d = bl702_hal::delay::McycleDelay::new(bl702_hal::SYSFREQ);
-
     loop {
         let r = serial.read();
         if let Ok(r) = r {

--- a/examples/serial_echo.rs
+++ b/examples/serial_echo.rs
@@ -10,10 +10,10 @@ use bl702_hal::{
     uart::*,
 };
 use core::fmt::Write;
-use embedded_hal::delay::blocking::DelayMs;
-use embedded_hal_zero::serial::Read;
+use embedded_hal::serial::Read;
+use embedded_hal_alpha::delay::blocking::DelayMs;
 
-use embedded_hal::digital::blocking::OutputPin;
+use embedded_hal_alpha::digital::blocking::OutputPin;
 use panic_halt as _;
 
 #[riscv_rt::entry]

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,10 +1,10 @@
 //! Delays
 
 use core::convert::Infallible;
-use embedded_hal::delay::blocking::{DelayMs, DelayUs};
+use embedded_hal_alpha::delay::blocking::{DelayMs, DelayUs};
 
-use embedded_hal_zero::blocking::delay::DelayMs as DelayMsZero;
-use embedded_hal_zero::blocking::delay::DelayUs as DelayUsZero;
+use embedded_hal::blocking::delay::DelayMs as DelayMsZero;
+use embedded_hal::blocking::delay::DelayUs as DelayUsZero;
 
 /// Use RISCV machine-mode cycle counter (`mcycle`) as a delay provider.
 ///

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -280,8 +280,8 @@ macro_rules! impl_glb {
         pub mod pin {
             use core::marker::PhantomData;
             use core::convert::Infallible;
-            use embedded_hal::digital::blocking::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin};
-            use embedded_hal_zero::digital::v2::{
+            use embedded_hal_alpha::digital::blocking::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin};
+            use embedded_hal::digital::v2::{
                 InputPin as InputPinZero,
                 OutputPin as OutputPinZero,
                 StatefulOutputPin as StatefulOutputPinZero,

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -4,8 +4,8 @@
 use crate::clock::Clocks;
 use crate::pac;
 use core::fmt;
-use embedded_hal::serial::nb::Read as ReadOne;
-use embedded_hal::serial::nb::Write as WriteOne;
+use embedded_hal_alpha::serial::nb::Read as ReadOne;
+use embedded_hal_alpha::serial::nb::Write as WriteOne;
 use embedded_time::rate::{Baud, Extensions};
 use nb::block;
 
@@ -238,7 +238,7 @@ where
     }
 }
 
-impl<PINS> embedded_hal::serial::nb::Write<u8> for Serial<pac::UART, PINS> {
+impl<PINS> embedded_hal_alpha::serial::nb::Write<u8> for Serial<pac::UART, PINS> {
     type Error = Error;
 
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
@@ -265,7 +265,7 @@ impl<PINS> embedded_hal::serial::nb::Write<u8> for Serial<pac::UART, PINS> {
     }
 }
 
-impl<PINS> embedded_hal::serial::nb::Read<u8> for Serial<pac::UART, PINS> {
+impl<PINS> embedded_hal_alpha::serial::nb::Read<u8> for Serial<pac::UART, PINS> {
     type Error = Error;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
@@ -278,7 +278,7 @@ impl<PINS> embedded_hal::serial::nb::Read<u8> for Serial<pac::UART, PINS> {
     }
 }
 
-impl<PINS> embedded_hal_zero::serial::Write<u8> for Serial<pac::UART, PINS> {
+impl<PINS> embedded_hal::serial::Write<u8> for Serial<pac::UART, PINS> {
     type Error = Error;
 
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
@@ -290,7 +290,7 @@ impl<PINS> embedded_hal_zero::serial::Write<u8> for Serial<pac::UART, PINS> {
     }
 }
 
-impl<PINS> embedded_hal_zero::serial::Read<u8> for Serial<pac::UART, PINS> {
+impl<PINS> embedded_hal::serial::Read<u8> for Serial<pac::UART, PINS> {
     type Error = Error;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
@@ -300,7 +300,7 @@ impl<PINS> embedded_hal_zero::serial::Read<u8> for Serial<pac::UART, PINS> {
 
 impl<UART, PINS> fmt::Write for Serial<UART, PINS>
 where
-    Serial<UART, PINS>: embedded_hal::serial::nb::Write<u8>,
+    Serial<UART, PINS>: embedded_hal_alpha::serial::nb::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         s.as_bytes()


### PR DESCRIPTION
bl602 has embedded-hal 1.0 alpha 5 as the default, but this is not useful for most people.
So we're swapping to 0.2.7 as the "standard".
This will make porting slightly more onerous, but mentally swapping these in my head is frustrating.