### PR TITLE
Fix RAM start address in linker scripts

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -1,8 +1,7 @@
 MEMORY
 {
     ROM       (rx)    : ORIGIN = 0x21000000, LENGTH = 128K
-    CACHE     (wxa)   : ORIGIN = 0x42010000, LENGTH = 4K
-    TCM_OCRAM (wxa)   : ORIGIN = 0x42011000, LENGTH = 124K
+    TCM_OCRAM (wxa)   : ORIGIN = 0x42014000, LENGTH = 112K
     FLASH     (rxa!w) : ORIGIN = 0x23000000, LENGTH = 2M
     HBNRAM    (wxa)   : ORIGIN = 0x40010000, LENGTH = 4K
 }
@@ -13,3 +12,17 @@ REGION_ALIAS("REGION_DATA", TCM_OCRAM);
 REGION_ALIAS("REGION_BSS", TCM_OCRAM);
 REGION_ALIAS("REGION_HEAP", TCM_OCRAM);
 REGION_ALIAS("REGION_STACK", TCM_OCRAM);
+
+/* Actual RAM mapping seems to be something like this (TODO: verify)
+  TCM_OCRAM length is 1BFFF (114687), so it extends to 0x42030000 
+*/
+
+/*
+  flash (rxai!w) : ORIGIN = 0x23000000, LENGTH = (2M)
+  CACHE     (wxa): ORIGIN = 0x42010000, LENGTH = 4K /* Note: this seems unlikely - maybe 0x4000? */
+  tcm      (wxa) : ORIGIN = 0x42014000, LENGTH = (48K)
+  ocram_1  (wxa) : ORIGIN = 0x42020000, LENGTH = (24K)  /* will not be initialized in bootrom */
+  ocram_2  (wxa) : ORIGIN = 0x42026000, LENGTH = (16K)  /* will be initialized in bootrom */
+  ocram_3  (wxa) : ORIGIN = 0x4202A000, LENGTH = (24K - __EM_SIZE)  /* will not be initialized in bootrom */
+  hbnram   (wxa) : ORIGIN = 0x40010000, LENGTH = (4K)
+*/

--- a/run_from_ram.x
+++ b/run_from_ram.x
@@ -1,8 +1,7 @@
 MEMORY
 {
     ROM       (rx)    : ORIGIN = 0x21000000, LENGTH = 128K
-    CACHE     (wxa)   : ORIGIN = 0x42010000, LENGTH = 4K
-    TCM_OCRAM (wxa)   : ORIGIN = 0x42011000, LENGTH = 124K
+    TCM_OCRAM (wxa)   : ORIGIN = 0x42014000, LENGTH = 112K
     FLASH     (rxa!w) : ORIGIN = 0x23000000, LENGTH = 2M
     HBNRAM    (wxa)   : ORIGIN = 0x40010000, LENGTH = 4K
 }


### PR DESCRIPTION
The original start address was from a linker script in bl_iot_sdk, but it's wrong.
Anything stored before 0x42014000 doesn't work, so moving start offset there.
This now matches what the bl_mcu_sdk scripts use.