### PR TITLE
Clean up CI issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "HAL for the Bouffalo Lab BL702 microcontroller family"
 [dependencies]
 bl702-pac = "0.0.2"
 embedded-time = "0.12.0"
-riscv = "0.10.0"
+riscv = "0.10.1"
 nb = "1.0"
 paste = "1.0"
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
@@ -20,7 +20,7 @@ ufmt = { version = "0.2", optional = true }
 ufmt-write = { version = "0.1", optional = true }
 
 [dev-dependencies]
-riscv-rt = "0.10.0"
+riscv-rt = "0.11.0"
 panic-halt = "0.2.0"
 st7735-lcd = "0.7"
 embedded-graphics = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ ufmt-write = { version = "0.1", optional = true }
 
 [dev-dependencies]
 riscv-rt = "0.11.0"
-panic-halt = "0.2.0"
 st7735-lcd = "0.7"
 embedded-graphics = "0.6.0"
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -53,18 +53,23 @@ pub enum SpiBitFormat {
     MsbFirst,
 }
 
+#[allow(clippy::missing_safety_doc)]
 /// MISO pins - DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait MisoPin<SPI> {}
 
+#[allow(clippy::missing_safety_doc)]
 /// MOSI pins - DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait MosiPin<SPI> {}
 
+#[allow(clippy::missing_safety_doc)]
 /// SS pins - DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait SsPin<SPI> {}
 
+#[allow(clippy::missing_safety_doc)]
 /// SCLK pins - DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait SclkPin<SPI> {}
 
+#[allow(clippy::missing_safety_doc)]
 /// Spi pins - DO NOT IMPLEMENT THIS TRAIT
 pub unsafe trait Pins<SPI> {}
 

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -12,8 +12,6 @@ use nb::block;
 
 #[cfg(feature = "print_serial")]
 use core::convert::Infallible;
-#[cfg(feature = "print_serial")]
-use ufmt::uwriteln;
 
 /// UART error
 #[derive(Debug)]


### PR DESCRIPTION
CI wasn't happy because of a transitive dependency on a version of the riscv crate that had been yanked.
Also removed an import from UART that wasn't used that was triggering a clippy warning - it can be re-added when it is used.
We aren't using panic-halt in our examples since we have a serial panic print, so drop that dep.
Disabled warnings on lack of `# Safety` comments on SPI pin traits - will want to move them to sealed traits in the future anyway.